### PR TITLE
support 'hostfile' in ansible.cfg as well, fix inventory directory handling

### DIFF
--- a/ansible-completion.bash
+++ b/ansible-completion.bash
@@ -39,7 +39,7 @@ _ansible_complete_host() {
     [ -d "$inventory_file" ] && grep_opts="$grep_opts -hR"
     local hosts=$(ansible ${inventory_file:+-i "$inventory_file"} all --list-hosts 2>&1 \
         && [ -e "$inventory_file" ] \
-        && [ -d "$inventory_file -o ! -x "$inventory_file" ] \
+        && [ -d "$inventory_file" -o ! -x "$inventory_file" ] \
         && grep $grep_opts '\[.*\]' "$inventory_file" | tr -d [] | cut -d: -f1)
 
     # list the hostnames with ansible command line and complete the list

--- a/ansible-completion.bash
+++ b/ansible-completion.bash
@@ -39,7 +39,7 @@ _ansible_complete_host() {
     [ -d "$inventory_file" ] && grep_opts="$grep_opts -hR"
     local hosts=$(ansible ${inventory_file:+-i "$inventory_file"} all --list-hosts 2>&1 \
         && [ -e "$inventory_file" ] \
-        && [ ! -x "$inventory_file" ] \
+        && [ -d "$inventory_file -o ! -x "$inventory_file" ] \
         && grep $grep_opts '\[.*\]' "$inventory_file" | tr -d [] | cut -d: -f1)
 
     # list the hostnames with ansible command line and complete the list

--- a/ansible-completion.bash
+++ b/ansible-completion.bash
@@ -33,7 +33,7 @@ _ansible_complete_host() {
     if [ -z "$inventory_file" ]; then
         [ -f /etc/ansible/ansible.cfg ] && inventory_file=$(awk \
             '/^inventory/{ print $3 }' /etc/ansible/ansible.cfg)
-        [ -f ansible.cfg ] && inventory_file=$(awk '/^inventory/{ print $3 }' ansible.cfg)
+        [ -f ansible.cfg ] && inventory_file=$(awk '/^(hostname|inventory)/{ print $3 }' ansible.cfg)
     fi
     # if inventory_file points to a directory, search recursively
     [ -d "$inventory_file" ] && grep_opts="$grep_opts -hR"

--- a/ansible-completion.bash
+++ b/ansible-completion.bash
@@ -33,7 +33,7 @@ _ansible_complete_host() {
     if [ -z "$inventory_file" ]; then
         [ -f /etc/ansible/ansible.cfg ] && inventory_file=$(awk \
             '/^inventory/{ print $3 }' /etc/ansible/ansible.cfg)
-        [ -f ansible.cfg ] && inventory_file=$(awk '/^(hostname|inventory)/{ print $3 }' ansible.cfg)
+        [ -f ansible.cfg ] && inventory_file=$(awk '/^(hostfile|inventory)/{ print $3 }' ansible.cfg)
     fi
     # if inventory_file points to a directory, search recursively
     [ -d "$inventory_file" ] && grep_opts="$grep_opts -hR"


### PR DESCRIPTION
Stay backwards compatible, not everyone runs the latest and greatest version of ansible or has updated their config files yet, hostfile is only deprecated but still supported in current ansible versions.

Also, fix the handling of inventory directories, which are executable as much as inventory scripts (which should not be searched, I agree).