### PR TITLE
broaden OSTYPE comparison to other types of linux

### DIFF
--- a/ansible-completion.bash
+++ b/ansible-completion.bash
@@ -155,7 +155,7 @@ _timestamp() {
 _timestamp_last_modified()  {
     local timestamp=''
 
-    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    if [[ "$OSTYPE" == "linux"* ]]; then
         # linux
         timestamp=$(stat -c "%Z" $1)
     else


### PR DESCRIPTION
For instance Alpine linux returns `linux-musl` in the `$OSTYPE` env variable.  

This small change should make it compatible with all linuxes