### PR TITLE
Bug fix: don't break if inventory_ignore_extensions set in ansible.cfg

### DIFF
--- a/ansible-completion.bash
+++ b/ansible-completion.bash
@@ -33,11 +33,11 @@ _ansible_complete_host() {
     # search in the ansible.cfg for a hostfile entry
     if [ -z "$inventory_file" ]; then
         [ -f /etc/ansible/ansible.cfg ] && inventory_file=$(awk \
-            '/^(hostfile|inventory)/{ print $3 }' /etc/ansible/ansible.cfg)
+            '/^(hostfile =|inventory =)/{ print $3 }' /etc/ansible/ansible.cfg)
         [ -f ${HOME}/.ansible.cfg ] && inventory_file=$(awk \
-            '/^(hostfile|inventory)/{ print $3 }' ${HOME}/.ansible.cfg)
+            '/^(hostfile =|inventory =)/{ print $3 }' ${HOME}/.ansible.cfg)
         [ -f ansible.cfg ] && inventory_file=$(awk \
-            '/^(hostfile|inventory)/{ print $3 }' ansible.cfg)
+            '/^(hostfile =|inventory =)/{ print $3 }' ansible.cfg)
     fi
 
     # if the $inventory_file value is a variable (e.g $HOME), we evaluate that

--- a/ansible-completion.bash
+++ b/ansible-completion.bash
@@ -37,7 +37,7 @@ _ansible_complete_host() {
         [ -f ${HOME}/.ansible.cfg ] && inventory_file=$(awk \
             '/^(hostfile[[:space:]]*=|inventory[[:space:]]*=[[:space:]]*)/{ print $3 }' ${HOME}/.ansible.cfg)
         [ -f ansible.cfg ] && inventory_file=$(awk \
-            '/^(hostfile =|inventory =)/{ print $3 }' ansible.cfg)
+            '/^(hostfile[[:space:]]*=[[:space:]]*|inventory[[:space:]]*=[[:space:]]*)/{ print $3 }' ansible.cfg)
     fi
 
     # if the $inventory_file value is a variable (e.g $HOME), we evaluate that

--- a/ansible-completion.bash
+++ b/ansible-completion.bash
@@ -33,7 +33,7 @@ _ansible_complete_host() {
     # search in the ansible.cfg for a hostfile entry
     if [ -z "$inventory_file" ]; then
         [ -f /etc/ansible/ansible.cfg ] && inventory_file=$(awk \
-            '/^(hostfile =|inventory =)/{ print $3 }' /etc/ansible/ansible.cfg)
+            '/^(hostfile[[:space:]]*=[[:space:]]*|inventory[[:space:]]*=[[:space:]]*)/{ print $3 }' /etc/ansible/ansible.cfg)
         [ -f ${HOME}/.ansible.cfg ] && inventory_file=$(awk \
             '/^(hostfile =|inventory =)/{ print $3 }' ${HOME}/.ansible.cfg)
         [ -f ansible.cfg ] && inventory_file=$(awk \

--- a/ansible-completion.bash
+++ b/ansible-completion.bash
@@ -35,7 +35,7 @@ _ansible_complete_host() {
         [ -f /etc/ansible/ansible.cfg ] && inventory_file=$(awk \
             '/^(hostfile[[:space:]]*=[[:space:]]*|inventory[[:space:]]*=[[:space:]]*)/{ print $3 }' /etc/ansible/ansible.cfg)
         [ -f ${HOME}/.ansible.cfg ] && inventory_file=$(awk \
-            '/^(hostfile =|inventory =)/{ print $3 }' ${HOME}/.ansible.cfg)
+            '/^(hostfile[[:space:]]*=|inventory[[:space:]]*=[[:space:]]*)/{ print $3 }' ${HOME}/.ansible.cfg)
         [ -f ansible.cfg ] && inventory_file=$(awk \
             '/^(hostfile =|inventory =)/{ print $3 }' ansible.cfg)
     fi


### PR DESCRIPTION
The previous way breaks if other configuration keywords which start with `inventory` are provided. This PR fixes that.

The fix isn't perfect though; it ignores potential extra whitespace in the `inventory = foo` setting. This could be handled with a better regexp.