### PR TITLE
Fix tilde support in paths

### DIFF
--- a/ansible-completion.bash
+++ b/ansible-completion.bash
@@ -39,6 +39,7 @@ _ansible_complete_host() {
         [ -f ansible.cfg ] && inventory_file=$(awk \
             '/^(hostfile[[:space:]]*=[[:space:]]*|inventory[[:space:]]*=[[:space:]]*)/{ print $3 }' ansible.cfg)
     fi
+    inventory_file="${inventory_file/\~\//$HOME/}"
 
     # if the $inventory_file value is a variable (e.g $HOME), we evaluate that
     # variable to get the value.


### PR DESCRIPTION
Ansible configuration file may contain ~ as the reference to the $HOME. In such cases script require a code to expand tilde into its value.